### PR TITLE
Add EPAM Website Navigation Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# EPAM Website Navigation Tests
+
+This repository contains automated tests for the EPAM website navigation using Playwright.
+
+## Test Scenarios
+
+1. **Navigate from homepage to Client Work page**
+   - Navigate to https://www.epam.com/
+   - Select "Services" from the header menu
+   - Click the "Explore Our Client Work" link
+   - Verify that the "Client Work" text is visible on the page
+
+## Setup
+
+1. Install dependencies:
+   ```
+   npm install
+   ```
+
+2. Install Playwright browsers:
+   ```
+   npx playwright install
+   ```
+
+## Running Tests
+
+Run all tests:
+```
+npm test
+```
+
+Run with UI mode:
+```
+npx playwright test --ui
+```
+
+## Test Reports
+
+After running tests, view the HTML report:
+```
+npx playwright show-report
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "epam-navigation-tests",
+  "version": "1.0.0",
+  "description": "Playwright tests for EPAM website navigation",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.40.0",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.2"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright Configuration
+ * See https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30000,
+  expect: {
+    timeout: 5000
+  },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    actionTimeout: 0,
+    baseURL: 'https://www.epam.com',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/tests/epam-navigation.spec.ts
+++ b/tests/epam-navigation.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Test Suite: EPAM Website Navigation
+ * This test verifies the navigation flow from homepage to Client Work section
+ */
+test('Navigate from homepage to Client Work page', async ({ page }) => {
+  // Step 1: Navigate to EPAM homepage
+  await test.step('Navigate to EPAM homepage', async () => {
+    await page.goto('https://www.epam.com/');
+    
+    // Verify page loaded successfully
+    await expect(page).toHaveTitle(/EPAM/);
+    console.log('Successfully navigated to EPAM homepage');
+  });
+
+  // Step 2: Select "Services" from the header menu
+  await test.step('Click on Services menu item', async () => {
+    // Wait for the header to be fully loaded
+    await page.waitForSelector('header');
+    
+    // Click on the Services menu item
+    await page.click('text=Services');
+    
+    // Verify Services menu is visible
+    await expect(page.locator('text=Services')).toBeVisible();
+    console.log('Successfully clicked on Services menu');
+  });
+
+  // Step 3: Click the "Explore Our Client Work" link
+  await test.step('Click on Explore Our Client Work link', async () => {
+    // Find and click the "Explore Our Client Work" link
+    await page.click('text=Explore Our Client Work');
+    
+    // Wait for navigation to complete
+    await page.waitForLoadState('networkidle');
+    console.log('Successfully clicked on Explore Our Client Work link');
+  });
+
+  // Step 4: Verify that the "Client Work" text is visible on the page
+  await test.step('Verify Client Work text is visible', async () => {
+    // Check if "Client Work" text is visible on the page
+    await expect(page.locator('text=Client Work')).toBeVisible();
+    console.log('Successfully verified Client Work text is visible');
+  });
+});


### PR DESCRIPTION
## EPAM Website Navigation Test

This PR adds an automated Playwright test script that verifies navigation from the EPAM homepage to the Client Work page.

### Test Scenario
1. Navigate to https://www.epam.com/
2. Select "Services" from the header menu
3. Click the "Explore Our Client Work" link
4. Verify that the "Client Work" text is visible on the page

### Implementation Details
- Created a TypeScript test script using Playwright
- Added proper configuration files (playwright.config.ts)
- Added package.json with necessary dependencies
- Added README with instructions on how to run the tests

### Test Results
The test was executed successfully, confirming that:
- The EPAM website loads correctly
- Navigation to the Services page works
- The "Explore Our Client Work" link is clickable
- The Client Work page loads with the expected text visible

This test can be used as a foundation for more comprehensive test suites for the EPAM website.