### PR TITLE
Add Playwright test for Epam Client Work verification

### DIFF
--- a/tests/epam-client-work-test.spec.ts
+++ b/tests/epam-client-work-test.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Navigate to Epam website and verify Client Work section', async ({ page }) => {
+  // Step 1: Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+
+  // Step 2: Select "Services" from the header menu
+  await page.click('text=Services');
+
+  // Step 3: Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Step 4: Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.locator('text=Client Work');
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
This pull request introduces a Playwright test script to verify the "Client Work" section on the Epam website.

### Test Scenario:
1. Navigate to https://www.epam.com/
2. Select "Services" from the header menu.
3. Click the "Explore Our Client Work" link.
4. Verify that the "Client Work" text is visible on the page.

### File Added:
- `tests/epam-client-work-test.spec.ts`

### Summary of Changes:
- Added a Playwright test script to automate the above scenario.

Please review and merge.