### PR TITLE
Add Playwright test for Client Work section

### DIFF
--- a/tests/client-work.spec.ts
+++ b/tests/client-work.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Navigate to EPAM and verify Client Work section', async ({ page }) => {
+  // Step 1: Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+  
+  // Step 2: Select "Services" from the header menu
+  await page.click('text=Services');
+  
+  // Step 3: Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+  
+  // Step 4: Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.locator('text=Client Work');
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
This PR adds a Playwright test script that navigates to the EPAM website, selects 'Services' from the header menu, clicks the 'Explore Our Client Work' link, and verifies that the 'Client Work' text is visible on the page.