### PR TITLE
Add EPAM Website Navigation Test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "epam-website-tests",
+  "version": "1.0.0",
+  "description": "Automated tests for EPAM website",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [
+    "playwright",
+    "testing",
+    "automation"
+  ],
+  "devDependencies": {
+    "@playwright/test": "^1.40.0",
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.2"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for EPAM website tests
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30 * 1000, // Maximum time one test can run
+  expect: {
+    timeout: 5000 // Maximum time to wait for assertions
+  },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'https://www.epam.com',
+    actionTimeout: 0,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,35 @@
+# EPAM Website Automated Tests
+
+This directory contains automated tests for the EPAM website using Playwright.
+
+## Test Scenarios
+
+### epam-client-work.spec.ts
+Tests the navigation flow from EPAM homepage to the Client Work page:
+1. Navigate to https://www.epam.com/
+2. Select "Services" from the header menu
+3. Click the "Explore Our Client Work" link
+4. Verify that the "Client Work" text is visible on the page
+
+## Running Tests
+
+To run the tests:
+
+```bash
+# Install dependencies
+npm install
+
+# Install Playwright browsers
+npx playwright install
+
+# Run tests
+npx playwright test
+```
+
+## Viewing Test Reports
+
+After running tests, you can view the HTML report:
+
+```bash
+npx playwright show-report
+```

--- a/tests/epam-client-work.spec.ts
+++ b/tests/epam-client-work.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Test Suite for EPAM website navigation and content verification
+ * 
+ * This test verifies the navigation flow from the EPAM homepage
+ * to the Client Work page through the Services menu.
+ */
+test('Navigate to Client Work page through Services menu', async ({ page }) => {
+  // Step 1: Navigate to EPAM homepage
+  await test.step('Navigate to EPAM homepage', async () => {
+    await page.goto('https://www.epam.com/');
+    
+    // Verify page loaded successfully
+    await expect(page).toHaveTitle(/EPAM/);
+  });
+
+  // Step 2: Select "Services" from the header menu
+  await test.step('Click on Services menu item', async () => {
+    // Wait for the header navigation to be visible
+    const servicesMenuItem = page.locator('header a:text("Services")').first();
+    await expect(servicesMenuItem).toBeVisible();
+    await servicesMenuItem.click();
+    
+    // Verify Services page loaded
+    await expect(page).toHaveURL(/.*\/services/);
+  });
+
+  // Step 3: Click the "Explore Our Client Work" link
+  await test.step('Click on Explore Our Client Work link', async () => {
+    // Find and click the "Explore Our Client Work" link
+    const clientWorkLink = page.getByRole('link', { name: /Explore Our Client Work/i });
+    await expect(clientWorkLink).toBeVisible();
+    await clientWorkLink.click();
+    
+    // Wait for navigation to complete
+    await page.waitForURL(/.*\/our-work/);
+  });
+
+  // Step 4: Verify that the "Client Work" text is visible on the page
+  await test.step('Verify Client Work text is visible', async () => {
+    // Check for "Client Work" text on the page
+    const clientWorkText = page.getByText('Client Work', { exact: false });
+    await expect(clientWorkText).toBeVisible();
+  });
+});


### PR DESCRIPTION
This PR adds an automated test script for navigating the EPAM website.

## Test Scenario
1. Navigate to https://www.epam.com/
2. Select "Services" from the header menu.
3. Click the "Explore Our Client Work" link.
4. Verify that the "Client Work" text is visible on the page.

## Implementation
- Created a Playwright TypeScript test script that follows the test scenario
- Added proper configuration files for Playwright
- Included documentation on how to run the tests

## Test Results
The test was executed successfully, confirming that:
- The EPAM website loads correctly
- Navigation to the Services page works
- The "Explore Our Client Work" link is clickable
- The "Client Work" text is visible on the destination page

This test can be used as a foundation for more comprehensive test coverage of the EPAM website.